### PR TITLE
fix: correctly display rest params

### DIFF
--- a/src/DocParam.js
+++ b/src/DocParam.js
@@ -5,10 +5,16 @@ class DocParam extends DocElement {
     super(parent.doc, DocElement.types.PARAM, data, parent)
     this.type = data.type.flat(5)
     this.optional = data.optional
+    this.variable = data.variable
   }
 
   get formattedName () {
     return this.optional ? `\`[${this.name}]\`` : `\`${this.name}\``
+  }
+
+  get formattedType () {
+    if (!this.variable) return super.formattedType
+    return super.formattedType.split('|').map(param => `...${param}`).join('|')
   }
 
   get url () {


### PR DESCRIPTION
This PR fixes variable parameters not showing the `...` indicating its a variable parameter