### PR TITLE
refactor: improve search

### DIFF
--- a/src/Doc.js
+++ b/src/Doc.js
@@ -73,6 +73,7 @@ class Doc extends DocBase {
   }
 
   get (...terms) {
+    const exclude = Array.isArray(terms[0]) ? terms.shift() : []
     terms = terms
       .filter(term => term)
       .map(term => term.toLowerCase())
@@ -82,7 +83,7 @@ class Doc extends DocBase {
 
     while (terms.length) {
       const term = terms.shift()
-      const child = elem.findChild(term)
+      const child = elem.findChild(term, exclude)
 
       if (!child) return null
       elem = terms.length && child.typeElement ? child.typeElement : child
@@ -98,7 +99,7 @@ class Doc extends DocBase {
     const filtered = []
 
     while (result.length > 0 && filtered.length < 10) {
-      const element = this.get(...result.shift().split('#'))
+      const element = this.get(filtered, ...result.shift().split('#'))
       if (excludePrivateElements && element.access === 'private') continue
       filtered.push(element)
     }

--- a/src/Doc.js
+++ b/src/Doc.js
@@ -116,7 +116,10 @@ class Doc extends DocBase {
 
     const embed = this.baseEmbed()
     embed.title = 'Search results:'
-    embed.description = searchResults.map(el => `**${el.link}**`).join('\n')
+    embed.description = searchResults.map(el => {
+      const prefix = el.embedPrefix
+      return `${prefix ? `${prefix} ` : ''}**${el.link}**`
+    }).join('\n')
     return embed
   }
 

--- a/src/DocBase.js
+++ b/src/DocBase.js
@@ -32,14 +32,21 @@ class DocBase {
     return filtered.length ? filtered : null
   }
 
-  findChild (query) {
+  findChild (query, exclude = []) {
     query = query.toLowerCase()
 
-    return Array.from(this.children.values()).find(
-      child => query.endsWith('()')
-        ? child.name.toLowerCase() === query.slice(0, -2) && child.docType === types.METHOD
-        : child.name.toLowerCase() === query
-    )
+    let docType = null
+    if (query.endsWith('()')) {
+      query = query.slice(0, -2)
+      docType = types.METHOD
+    } else if (query.startsWith('e-')) {
+      query = query.slice(2)
+      docType = types.EVENT
+    }
+
+    return Array.from(this.children.values()).find(child => (
+      !exclude.includes(child) && child.name.toLowerCase() === query && (!docType || child.docType === docType)
+    ))
   }
 
   get classes () {

--- a/src/DocElement.js
+++ b/src/DocElement.js
@@ -27,12 +27,20 @@ class DocElement extends DocBase {
     const { types } = DocElement
     const emoji = char => `:regional_indicator_${char}:`
 
-    if (this.docType === types.EVENT) return emoji('e')
-    else if (this.docType === types.INTERFACE) return emoji('i')
-    else if (this.docType === types.METHOD) return emoji('m')
-    else if (this.docType === types.TYPEDEF) return emoji('t')
-    else if (this.docType === types.CLASS) return emoji('c')
-    return null
+    switch (this.docType) {
+      case types.CLASS:
+        return emoji('c')
+      case types.EVENT:
+        return emoji('e')
+      case types.INTERFACE:
+        return emoji('i')
+      case types.METHOD:
+        return emoji('m')
+      case types.TYPEDEF:
+        return emoji('t')
+      default:
+        return null
+    }
   }
 
   get anchor () {

--- a/src/DocElement.js
+++ b/src/DocElement.js
@@ -23,11 +23,17 @@ class DocElement extends DocBase {
     this.access = data.access || 'public'
   }
 
+  get anchor () {
+    if (this.static) return 's-'
+    else if (this.docType === DocElement.types.EVENT) return 'e-'
+    return null
+  }
+
   get url () {
     if (!this.doc.baseDocsURL) return null
 
     const path = this.parent
-      ? `${this.parent.docType}/${this.parent.name}?scrollTo=${this.static ? 's-' : ''}${this.name}`
+      ? `${this.parent.docType}/${this.parent.name}?scrollTo=${this.anchor || ''}${this.name}`
       : `${this.docType}/${this.name}`
 
     return `${this.doc.baseDocsURL}/${path}`

--- a/src/DocElement.js
+++ b/src/DocElement.js
@@ -23,6 +23,18 @@ class DocElement extends DocBase {
     this.access = data.access || 'public'
   }
 
+  get embedPrefix () {
+    const { types } = DocElement
+    const emoji = char => `:regional_indicator_${char}:`
+
+    if (this.docType === types.EVENT) return emoji('e')
+    else if (this.docType === types.INTERFACE) return emoji('i')
+    else if (this.docType === types.METHOD) return emoji('m')
+    else if (this.docType === types.TYPEDEF) return emoji('t')
+    else if (this.docType === types.CLASS) return emoji('c')
+    return null
+  }
+
   get anchor () {
     if (this.static) return 's-'
     else if (this.docType === DocElement.types.EVENT) return 'e-'

--- a/src/DocElement.js
+++ b/src/DocElement.js
@@ -28,18 +28,12 @@ class DocElement extends DocBase {
     const emoji = char => `:regional_indicator_${char}:`
 
     switch (this.docType) {
-      case types.CLASS:
-        return emoji('c')
-      case types.EVENT:
-        return emoji('e')
-      case types.INTERFACE:
-        return emoji('i')
-      case types.METHOD:
-        return emoji('m')
-      case types.TYPEDEF:
-        return emoji('t')
-      default:
-        return null
+      case types.CLASS: return emoji('c')
+      case types.EVENT: return emoji('e')
+      case types.INTERFACE: return emoji('i')
+      case types.METHOD: return emoji('m')
+      case types.TYPEDEF: return emoji('t')
+      default: return null
     }
   }
 


### PR DESCRIPTION
This PR refactors the search to include emojis labeling each element
![image](https://user-images.githubusercontent.com/28943913/94877625-f938a300-0452-11eb-825f-efdf4d258fbb.png)

This PR also fixes the search to not include duplicate results in the case a class has an event and a method with the same name, see 
![image](https://user-images.githubusercontent.com/28943913/94876445-942f7e00-044f-11eb-861b-9f3d66cdab02.png)
and also allow for querying the event directly by searching `e-eventName`

the implementation is a bit funky but i think it'll do