### PR TITLE
chore: rename master

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ const Doc = require('discord.js-docs')
 
 ### Doc.fetch(sourceName[, options])
 Fetches and parses the docs for the given project.\
-`sourceName` can be any of the predefined values (`stable`, `master`, `commando`, `rpc`, `akairo`, `akairo-master` and `collection`)
-or an URL which will return the raw generated docs (e.g https://raw.githubusercontent.com/discordjs/discord.js/docs/master.json ).\
+`sourceName` can be any of the predefined values (`stable`, `main`, `commando`, `rpc`, `akairo`, `akairo-master` and `collection`)
+or an URL which will return the raw generated docs (e.g https://raw.githubusercontent.com/discordjs/discord.js/docs/main.json ).\
 Once a documentation is fetched it will be cached. Use `options.force` to avoid this behavior.
 
 **Params**:
@@ -26,7 +26,7 @@ Once a documentation is fetched it will be cached. Use `options.force` to avoid 
 **Returns**: `Promise<Doc?>`
 
 ```js
-const doc = await Doc.fetch('master')
+const doc = await Doc.fetch('main')
 const doc = await Doc.fetch('akairo-master', { force: true })
 const doc = await Doc.fetch(
   'https://raw.githubusercontent.com/discordjs/discord-rpc/docs/master.json',

--- a/sources.json
+++ b/sources.json
@@ -1,9 +1,9 @@
 {
   "stable": "https://raw.githubusercontent.com/discordjs/discord.js/docs/stable.json",
-  "master": "https://raw.githubusercontent.com/discordjs/discord.js/docs/master.json",
+  "main": "https://raw.githubusercontent.com/discordjs/discord.js/docs/main.json",
   "commando": "https://raw.githubusercontent.com/discordjs/commando/docs/master.json",
   "rpc": "https://raw.githubusercontent.com/discordjs/rpc/docs/master.json",
   "akairo": "https://raw.githubusercontent.com/discord-akairo/discord-akairo/docs/stable.json",
   "akairo-master": "https://raw.githubusercontent.com/discord-akairo/discord-akairo/docs/master.json",
-  "collection": "https://raw.githubusercontent.com/discordjs/collection/docs/master.json"
+  "collection": "https://raw.githubusercontent.com/discordjs/collection/docs/main.json"
 }


### PR DESCRIPTION
discord.js had its default branch changed to `main`