### PR TITLE
chore: update sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ const Doc = require('discord.js-docs')
 
 ### Doc.fetch(sourceName[, options])
 Fetches and parses the docs for the given project.\
-`sourceName` can be any of the predefined values (`stable`, `main`, `commando`, `rpc`, `akairo`, `akairo-master` and `collection`)
-or an URL which will return the raw generated docs (e.g https://raw.githubusercontent.com/discordjs/discord.js/docs/main.json ).\
+`sourceName` can be any of the predefined values (`stable`, `main`, `commando`, `rpc`, `akairo`, `collection`, `builders`, `voice` and `rest`)
+or an URL which will return the raw generated docs (e.g https://raw.githubusercontent.com/discordjs/docs/main/discord.js/main.json ).\
 Once a documentation is fetched it will be cached. Use `options.force` to avoid this behavior.
 
 **Params**:
@@ -27,9 +27,9 @@ Once a documentation is fetched it will be cached. Use `options.force` to avoid 
 
 ```js
 const doc = await Doc.fetch('main')
-const doc = await Doc.fetch('akairo-master', { force: true })
+const doc = await Doc.fetch('akairo', { force: true })
 const doc = await Doc.fetch(
-  'https://raw.githubusercontent.com/discordjs/discord-rpc/docs/master.json',
+  'https://raw.githubusercontent.com/discordjs/rpc/docs/master.json',
   { force: true }
 )
 ```

--- a/sources.json
+++ b/sources.json
@@ -1,9 +1,11 @@
 {
-  "stable": "https://raw.githubusercontent.com/discordjs/discord.js/docs/stable.json",
-  "main": "https://raw.githubusercontent.com/discordjs/discord.js/docs/main.json",
+  "stable": "https://raw.githubusercontent.com/discordjs/docs/main/discord.js/stable.json",
+  "main": "https://raw.githubusercontent.com/discordjs/docs/main/discord.js/main.json",
   "commando": "https://raw.githubusercontent.com/discordjs/commando/docs/master.json",
   "rpc": "https://raw.githubusercontent.com/discordjs/rpc/docs/master.json",
-  "akairo": "https://raw.githubusercontent.com/discord-akairo/discord-akairo/docs/stable.json",
-  "akairo-master": "https://raw.githubusercontent.com/discord-akairo/discord-akairo/docs/master.json",
-  "collection": "https://raw.githubusercontent.com/discordjs/collection/docs/main.json"
+  "akairo": "https://raw.githubusercontent.com/discord-akairo/discord-akairo/docs/master.json",
+  "collection": "https://raw.githubusercontent.com/discordjs/docs/main/collection/main.json",
+  "builders": "https://raw.githubusercontent.com/discordjs/docs/main/builders/main.json",
+  "voice": "https://raw.githubusercontent.com/discordjs/docs/main/voice/main.json",
+  "rest": "https://raw.githubusercontent.com/discordjs/docs/main/rest/main.json"
 }

--- a/src/DocTypedef.js
+++ b/src/DocTypedef.js
@@ -3,7 +3,7 @@ const DocElement = require('./DocElement')
 class DocTypedef extends DocElement {
   constructor (doc, data) {
     super(doc, DocElement.types.TYPEDEF, data)
-    this.type = data.type.flat(5)
+    this.type = data.type ? data.type.flat(5) : 'Object'
   }
 }
 


### PR DESCRIPTION
- Fixes the URL for `stable`, `main` and `collection`
- Renames `akairo-master` to `akairo` because the akairo stable docs got deleted
- Adds `builders`, `voice` and `rest`

The `src/DocTypedef.js` change is necessary because the new TS docgen doesn't return a type property for interfaces and enums.