### PR TITLE
fix: use v13/v14+ docs url

### DIFF
--- a/src/Doc.js
+++ b/src/Doc.js
@@ -41,7 +41,7 @@ class Doc extends DocBase {
 
   get baseURL () {
     switch (this.project) {
-      case DJS: return 'https://discord.js.org'
+      case DJS: return 'https://old.discordjs.dev'
       case AKAIRO: return 'https://discord-akairo.github.io'
       default: return null
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -105,7 +105,7 @@ export default class Doc extends DocBase {
     public branch: string;
 
     get repoURL(): `https://github.com/${string}/${keyof DocsSources}/blob/${string}`;
-    get baseURL(): "https://discord.js.org" | "https://discord-akairo.github.io" | null;
+    get baseURL(): "https://old.discordjs.dev" | "https://discord-akairo.github.io" | null;
     get baseDocsURL(): `${string}/#/docs/${keyof DocsSources}/${string}` | null;
     get icon(): `${string}/favicon.ico` | null;
     get color(): 0x2296f3 | 0x87202f | null;


### PR DESCRIPTION
`discord.js.org` is for the next version, not for the v13/v14+. To keep codes like `${this.baseURL}/#/docs/${repo}/${this.branch}` `${this.doc.baseDocsURL}/${path}` working, it should use `old.discordjs.dev` as the baseURL.