### PR TITLE
Fixed issue where firstResult was accessed incorrectly

### DIFF
--- a/src/Doc.ts
+++ b/src/Doc.ts
@@ -149,7 +149,7 @@ export class Doc extends DocBase {
 			const firstResult = result.shift();
 			if (!firstResult) continue;
 			//@ts-ignore
-			const element = this._getWithExclude(filtered, ...firstResult.split('#'));
+			const element = this._getWithExclude(filtered, ...firstResult.item.name.split("#"));
 			if (excludePrivateElements && element?.access === 'private') continue;
 			if (element) filtered.push(element);
 		}


### PR DESCRIPTION
Discovered an issue where firstResult.split is not a function because firstResult is an object:
```ts
{ item: { id: 'Client#isReady', name: 'isReady' }, refIndex: 474 }
```
Changed `firstResult.split("#"));` to `firstResult.item.name.split("#"));` as this seems to be the intended behavior, and works as intended when I tested the code. This makes the results go from max 1 relevant result to 20 or however may relevant results there actually are.

Currently `firstResult.split("#"));` throws a top level error that is not handled by this repository, meaning the users of the library will manually have to handle it.